### PR TITLE
Update python-full-stack-way-object-oriented-advanced.md

### DIFF
--- a/article/python-full-stack-way-object-oriented-advanced.md
+++ b/article/python-full-stack-way-object-oriented-advanced.md
@@ -50,7 +50,7 @@ Process finished with exit code 0
 
 ## 执行父类的构造方法
 ```Python
-class Annimal:
+class Annimal(object):
     def __init__(self):
         print("Annimal的构造方法")
         self.ty = "动物"


### PR DESCRIPTION
执行父类的构造方法，代码执行报错如下：
super(Cat, self).__init__()
TypeError: super() argument 1 must be type, not classobj
python中super只能应用于新类，而不能应用于经典类，可改为：
class Annimal(object):
     ...
