### PR TITLE
Update python-standard-library-paramiko.md

### DIFF
--- a/article/python-standard-library-paramiko.md
+++ b/article/python-standard-library-paramiko.md
@@ -47,6 +47,8 @@ b'Filesystem      Size  Used Avail Use% Mounted on\n/dev/sda3        48G  3.3G  
 
 ```bash
 [root@linux-node1 ~]# ssh-keygen -t rsa -f ~/.ssh/id_rsa -P ''
+[root@linux-node1 ~]# cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+[root@linux-node1 ~]# chmod 600 ~/.ssh/authorized_keys
 ```
 然后下载`/root/.ssh/id_rsa`下载下来，复制到`E:\python-intensive-training\`目录系，下面是在`windows`下使用`paramiko`连接脚本如下
 ```python


### PR DESCRIPTION
fix paramiko.ssh_exception.PasswordRequiredException: Private key file is encrypted
如果没有添加服务器自己的公钥到 authorized_keys，只用私钥 id_rsa，根本没办法连接